### PR TITLE
Add main categories to desktop entry.

### DIFF
--- a/electronic-wechat.desktop
+++ b/electronic-wechat.desktop
@@ -5,4 +5,4 @@ Exec=/opt/electronic-wechat-linux-x64/electronic-wechat %U
 Terminal=false
 Type=Application
 Icon=/opt/electronic-wechat-linux-x64/assets/icon.png
-Categories=Chat;
+Categories=Network;Utility;Chat;


### PR DESCRIPTION
Add **main categories** in the .desktop file to show it appropriately in some desktop environments.
The previous `Categories=Chat;` entry put electronic-wechat into Lost & Found category because it didn't specify the main category. "Chat" is an additional category.
![screenshot_20190101_084845](https://user-images.githubusercontent.com/22290018/50569544-5d23c880-0da2-11e9-949a-d16e4537a797.png)
Specifying `Categories=Network;Utility;Chat;` put electronic-wechat into "Internet" and "Utilities" categories in KDE Plasma.
![screenshot_20190101_082828](https://user-images.githubusercontent.com/22290018/50569558-affd8000-0da2-11e9-84d2-931bbf987e17.png)
GNOME users don't bother this because GNOME doesn't have menu categories by default. Other desktop environments are not tested.
Reference: [freedesktop.org Desktop Menu Specification](https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html)

My desktop environment:
Operating System: Kubuntu 18.10
KDE Plasma Version: 5.14.4
Qt Version: 5.11.1
KDE Frameworks Version: 5.52.0