### PR TITLE
Delete "Utility" from .desktop file

### DIFF
--- a/electronic-wechat.desktop
+++ b/electronic-wechat.desktop
@@ -5,4 +5,4 @@ Exec=/opt/electronic-wechat-linux-x64/electronic-wechat %U
 Terminal=false
 Type=Application
 Icon=/opt/electronic-wechat-linux-x64/assets/icon.png
-Categories=Network;Utility;Chat;
+Categories=Network;InstantMessaging;


### PR DESCRIPTION
I know this sounds like a joke.
While I was showering, I realized that WeChat isn't an application in the "Utility" category.
"Utilities" are accessory applications like archiver, calculator, clock.
For example, Telegram doesn't have "Utility" in its category:
`Categories=Network;InstantMessaging;Qt;`
I also noticed that there is a difference between "Chat" and "Instant Messaging." IMO WeChat is an instant messaging app instead of a chat app.
I am sorry for I made that negligent pull request without even thinking about it.

Reference: 
* [Desktop Menu Specification - freedesktop.org](https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry)
* https://github.com/telegramdesktop/tdesktop/blob/dev/lib/xdg/telegramdesktop.desktop
* [Differences Between Chat and Instant Messaging - Lifewire](https://www.lifewire.com/difference-between-chat-and-instant-messaging-3969422)
* https://en.wikipedia.org/wiki/WeChat (Notice that the "Type" is "Instant messaging client")